### PR TITLE
Fix Dockerfile: dhclient install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM node:22-alpine
 
-RUN apk add --no-cache dhclient
+RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.20/main dhclient
 ENV NODE_ENV=production
 WORKDIR /app
 
 COPY ["package.json", "package-lock.json*", "./"]
-RUN npm ci --production --silent 
+RUN npm ci --production --silent
 
 COPY . .
 


### PR DESCRIPTION
dhclient has been removed starting with Alpine 3.21.0.
See: https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.21.0