### PR TITLE
Proxy ONVIF Events and PTZ to upstream camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,233 +1,101 @@
-# 📸 Virtual Onvif Proxy
-Simple docker container to add any RTSP stream into Unify Protect 5+
+# Virtual ONVIF Proxy
 
-This is a continuation from the simple virtual ONVIF proxy that was originally released by Daniela Hase.
-  
-This repository has added features such as ...
-- Making it a pure docker appliance. Pull-And-Run™
-- Only deals with RSTP to ONVIF proxies
-- Auto creates MAC addresses and registers IPv4 with DHCP
-- more to come...
+Fakes ONVIF Device and Media services in front of an RTSP camera so UniFi Protect can adopt it as a native ONVIF cam, then proxies ONVIF Events, PTZ, and Imaging through to the real camera.
 
-What can you adopt?
-- Adopt `IP camera --> RTSP (h264) --> Protect` 
-- Adopt `Raspberry Pi Camera --> uv4l --> RTSP (h254) -- Protect`
-- Adopt `Analog --> NVR --> RTSP (h264) --> Protect` 
-- Adopt `WebCam --> go2rtc --> RTSP (h264) --> Protect`
-- Adopt `... Anything RTSP --> Protect`
+> **In UniFi Protect 7.1.60:**
+>
+> - PTZ joystick control on third-party cameras works without an AI Port. The AI Port is the documented requirement; this proxy makes it work without one.
+> - Motion events from third-party cameras show up on the Protect timeline.
 
-IP camera --> RTSP (h264) --> Protect
+Forked from [p10tyr/rtsp-to-onvif](https://github.com/p10tyr/rtsp-to-onvif), which built the adoption and streaming pieces. This fork adds the service passthroughs that make the two things above work.
 
-![image](https://github.com/user-attachments/assets/7fa9ab55-7830-4602-a1e5-d1ad9184117e)
+## What works
 
-Analog! --> NVR --> RTSP (h264) --> Protect
+- **Motion events** via Protect 7.1.60's third-party motion alert pipeline. `CreatePullPointSubscription` returns a subscription URL hosted on the proxy itself, so the cam stays unreachable on its isolated network. `PullMessages`, `Renew`, `Unsubscribe`, and per-subscription cleanup all work.
+- **PTZ control** for cams with `ptz: true` in config. `ContinuousMove`, `Stop`, `AbsoluteMove`, `RelativeMove`, `GetStatus`, presets. Profile tokens are translated (`main_stream` to `Profile_1`, etc.) so Hikvision-family cams accept the requests instead of returning `ter:NoProfile`.
+- **Imaging settings** for every cam. Brightness, contrast, IR-cut, white balance, focus. Same token translation pattern, `video_src_token` to `VideoSource_1`.
+- **No credentials in config.** The `wsse:Security` UsernameToken Protect sends at every request is forwarded upstream unchanged, so the password you typed at adoption is the one the cam actually validates.
+- **Snapshots** through the existing TCP forwarder. The cam returns a Digest auth challenge, Protect handles the handshake, the image flows back. The upstream README says snapshot is unimplemented; that's stale, it works.
 
-![analog-dvr-rtsp](https://github.com/user-attachments/assets/ef401f8d-c56c-4ab0-8a44-630823a35ad7)
+## Tested on
 
+- 4x Luma Surveillance LUM-310-DOM-IP-BL (Hikvision OEM), firmware V5.5.52
+- 1x Luma LUM-310-PTZ-IP-WH, firmware V5.5.6
+- 1x Luma LUM-510-PTZ-IP-WH, firmware V5.5.6
+- UDM with UniFi Protect 7.1.60
+- Running as a systemd service on a Raspberry Pi (not the upstream's Docker path, but macvlan works the same way)
 
-# 🧾 Getting Started
+The profile and video-source token translation tables are hardcoded against the Hikvision/Luma `Profile_N` / `VideoSource_N` convention. Dahua, Reolink, Amcrest etc. likely use different tokens. If you try this with one of those and PTZ or imaging returns `ter:InvalidArgVal`, open an issue with what your cam's `GetProfiles` and `GetVideoSources` return.
 
-In a few steps you will have everything needed to run container first time. This will auto confiugre IP's for you.
-If you want more control over MAC's and IP's scroll down to Router Setup
+## Performance
 
-## Docker compose
+Sample stats from a Raspberry Pi 4 Model B (4 GB, Debian, Node 18.13), six cameras configured, under normal load (Protect polling for motion events, fetching snapshots, RTSP forwarding through to all 6 cams):
 
-Create a directory locally where you will keep your compose and config files.
+- Memory: around 380 MB RSS after ~1 hour uptime. About 10% of the Pi's 4 GB. Most of the footprint is `node-tcp-proxy` buffering active RTSP streams; the ONVIF SOAP layer itself is minor.
+- CPU: ~65% of one core on average (Node's JS work is single-threaded), which is roughly 16% of total on a 4-core Pi 4.
+- ~25 open TCP connections (RTSP forwarders, snapshot connections, ONVIF SOAP listeners across 6 virtual cams).
+- 1 process, ~11 threads (Node main + libuv pool + V8 helpers).
 
-1. Create a directory and change into it
-  - `mkdir rtsp-to-onvif` and `cd rtsp-to-onvif`
-2. Download the compose.yaml file
-  - `wget https://raw.githubusercontent.com/p10tyr/rtsp-to-onvif/refs/heads/release/compose.yaml`
-3. Download the config.example.yaml and clone it
-  - `wget https://raw.githubusercontent.com/p10tyr/rtsp-to-onvif/refs/heads/release/config.example.yaml`
-  - `cp config.example.yaml config.yaml`
-4. Edit and configure your cameras
-  - `nano config.yaml`
-5. Run compose in attached mode and check for any messages.
-  - `sudo docker compose up`
-6. If you see the cameras show up in Protect then you can run docker in detached mode (or use Dockge, Portainer, etc...)
-  - `sudo docker compose up d`
+The Pi 4 has plenty of headroom. Smaller hardware (Pi 3, Zero 2 W) is untested.
 
+## Install
 
-## Config file
+Same docker compose flow as upstream:
 
-- You just need to supply the bare minimum for each camera
-- Autoconfigure MAC addresses all use Unicast LAA prefix `1A:11:B0` and the NIC address will be random
-- UUID addresses will be added automatically
-- IPv4 will come from your DHCP server
+```bash
+mkdir rtsp-to-onvif && cd rtsp-to-onvif
+wget https://raw.githubusercontent.com/connorgallopo/rtsp-to-onvif/release/compose.yaml
+wget https://raw.githubusercontent.com/connorgallopo/rtsp-to-onvif/release/config.example.yaml
+cp config.example.yaml config.yaml
+nano config.yaml
+sudo docker compose up
+```
 
-> ℹ️ **NOTE** 
-> 
-> This file will be overwritten during automatic configuration so comments will be lost.
-> 
-> No username or passwords required here!
+If the cameras show up in Protect's adoption queue, you're good. `sudo docker compose up -d` to detach.
 
+## Config
+
+Bare-minimum per camera, with the new `ptz: true` flag on cams that support PTZ:
 
 ```yaml
 onvif:
-  - name: BulletCam                               # A user define named that will show up in the consumer device. Use letters only, no spaces or special characters
-    dev: enp2s0 #eth0                             # Network interface to add virtual IP's too. use ip addr to find your name
+  - name: FrontDoor
+    dev: eth0
+    ptz: false                        # set true if this cam supports PTZ
     target:
-      hostname: 192.168.1.187                      # Your cameras IPv4 address
+      hostname: 192.168.1.187
       ports:
-        rtsp: 554                                  # Your cameras RTSP port. Typically 554
-        snapshot: 80                               # Cameras non https port for snapshots
+        rtsp: 554
+        snapshot: 80
     highQuality:
-      rtsp: /Streaming/Channels/101/                    # The RTSP Path
-      snapshot: /ISAPI/Streaming/Channels/101/picture   # Snapshot path - not working yet
-      width: 2048                                       # The Video Width
-      height: 1536                                      # The Video Height
-      framerate: 15                                     # The Video Framerate/FPS
-      bitrate: 3072                                     # The Video Bitrate in kb/s
-      quality: 4                                        # Quality, leave this as 4 for the high quality stream.
-    ports:                                              # Virtual server ports. No need to change these unles you run into port already in use problems
+      rtsp: /Streaming/Channels/101/
+      snapshot: /ISAPI/Streaming/Channels/101/picture
+      width: 1920
+      height: 1080
+      framerate: 30
+      bitrate: 4096
+      quality: 4
+    ports:
       server: 8081
       rtsp: 8554
       snapshot: 8080
-    #mac - automatically added here and IP comes from DHCP- Add your own if you know what you doing
-    #uuid - ONVIF ID - automatically added here. If you change it Protect will think its a different camera
 ```
 
+MAC and UUID are auto-generated on first run.
+
+## Notes
+
+- Credentials go in Protect at adoption time. They're not stored on the proxy or in `config.yaml`. The proxy forwards the WS-Security header Protect sends, so the password Protect knows is the one the cam validates.
+- PTZ is gated by a per-cam `ptz: true` flag. Auto-detection would need either credentials in config (against the no-creds-in-config rule) or refactoring `device_service` out of the SOAP library binding.
+- Each downstream client gets its own upstream event subscription. Cams advertise `MaxPullPoints=10`, the proxy caps at 32 active subs per cam, so a single Protect controller is fine. Multi-consumer setups (Protect plus Frigate plus Scrypted on the same proxy) burn upstream slots 1:1 with consumers.
+
+## Not tested
+
+- Smart event topics (`tns1:RuleEngine/ObjectDetector`, person/vehicle classifiers). The cams I have don't emit them. The proxy passes through whatever topics the cam advertises, so if your cam emits these they should reach Protect.
+- Non-Hikvision-family cameras. Profile and video-source token translation tables assume the `Profile_N` / `VideoSource_N` naming convention.
+- Protect versions other than 7.1.60.
+- Hardware smaller than a Pi 4.
 
 ## Credits
-Thank you Daniela Hase for relasing the original script to the public!
-Original repository https://github.com/daniela-hase/onvif-server
 
-It has truly inspired me and gave me so many ideas! 
-That is why I had to fork your original repo so that I could develop this further to be a docker appliance.
-
-## Unifi Protect
-Tested on Unifi Protect 5.0.40+
-
-Once the device shows up in protect, make sure the correct MAC address is assigned to the IP before adopting. 
-You can then adopt it and provide the username and password that are set on the real RTSP device.
-
-Known Limitations
-
-> "Third-party features such as analytics, audio playback, and pan-tilt-zoom (PTZ) control are not supported." - Unify Support
-
-- Seems to only support recording normal/high profile h264 video streams at the moment
-- Your luck with h265 may vary
-- Scrubbing does not seem to work? Possibly depends on the h264 implementaion on the camera
-- Snapshot not implemented yet. Hope it works.
-- HighProfile support only for now - You can supply LowProfile but that shows up as an extra camera.
-
-
-# ⚒️ Roadmap
-- Simplyfy docker - DONE
-  - Only run in Docker - DONE
-  - Auto virtual MAC registrations - DONE
-  - Register with DCHP - DONE
-  - More debug messages - DONE
-- Learn about the ONVIF Profile S
-  - Implement snapshot functionality?
-  - Implement some other features?
-
-
-# 🛜 Docker and Docker Compose
-
-Debug is enabled byu default in compose.yaml
-Once you have setup complete you can disable it.
-
-## compose.yaml file 
-
-You don't really have to change anything in this file.
-It has all the settings and permsions required to make it just work.
-
-Some properties
-- `volumnes: ./config.yaml:/onvif.yaml` - where your config file is. Next step
-- `cap_add: NET_ADMIN` - Required to create virtual networks based on config file
-- `environment: DEBUG:1` - Uncommnet if you need more debug logs to show up
-
-## Router setup
-
-ONVIF discovery works by using MAC addresses.
-If you are happy with DHCP you can skip this step
-
-If you really static reservations - Do that BEFORE running the container.
-
-Add static reservatations using LAA MAC's
-- MAC's starting with `x2:xx:xx:xx:xx:xx`,`x6:xx:xx:xx:xx:xx`,`xA:xx:xx:xx:xx:xx` and `xE:xx:xx:xx:xx:xx` are Locally Administered Addresses (LAA)
-
-
-Virtual ONVIF 1
-- MAC 0A:00:00:00:00:51
-- IP 192.168.51
-
-Virtual ONVIF 2
-- MAC 0A:00:00:00:00:52
-- IP 192.168.52
-
-## Konwn problems
-
-Usuaully mulitple camera will just work out the box with the same server ports working for each virtual IP 
-
-If you seem to have problems like
-- MAC Addresses not showing properly for multiple cameras in Protect
-- Port numbers in use error during startup
-- MAC shows the wrong IP
-
-Generally depends from OS to OS. 
-Eg in Ubuntu 22. 
-
-You need to run these commands to allow virtual interface max advertising - but you still need a differnt port per virtual IP
-
-```bash
-sudo sysctl -w net.ipv4.conf.all.arp_ignore=1
-sudo sysctl -w net.ipv4.conf.all.arp_announce=2
-```
-
-
-### Other stuff
-
-Misc notes
-
----
-
-Remove a virutal IP on the host without rebooting
-`sudo ip link del dev rtsp2onvif_<number>`
-
----
-
-Wrapping an RTSP Stream
-
-This tool is used to create ONVIF devices from regular RTSP streams by creating the following configuration.
-
-Cameras before ONVIF had all kinds of weird and wonderful implemenations
-
-You will have to find out the stream and snapshot details with your own research, by seraching the web for URLS.
-You should verify the stream using VLC and the snapshot URL using a browser.
-
-Things to look out for
-- http is enabled (for snapshots)
-- if snapshot is not working, try admin account. some cameras are like that
-- rtsp is enabled ideally on port 554
-
-**RTSP Example:**
-Assume you have this RTSP stream:
-```txt
-rtsp://192.168.1.32:554/Streaming/Channels/101/
-       \__________/ \_/\______________________/
-            |       Port    |
-         Hostname           |
-                          Path
-```
-If your RTSP url does not have a port it uses the default port 554.
-
-Your RTSP url may contain a username and password - those should NOT be included in the config file.
-Instead you will have to enter them in the software that you plan on consuming this Onvif camera in, for example during adoption in Unifi Protect.
-
-Next you need to figure out the resolution and framerate for the stream. If you don't know them, you can use VLC to open the RTSP stream and check the _Media Information_ (Window -> Media Information) for the _"Video Resolution"_ and _"Frame rate"_ on the _"Codec Details"_ page, and the _"Stream bitrate"_ on the _"Statistics"_ page. The bitrate will fluctuate quite a bit most likely, so just pick a number that is close to it (e.g. 1024, 2048, 4096 ..).
-
-You can either randomly change a few numbers of the UUID, or use a UUIDv4 generator[^3].
-
-If you have a separate low-quality RTSP stream available, fill in the information for the `lowQuality` section above but this shows up as a seperate camera in unify. 
-
-> [!NOTE]
-> Since we don't provide a snapshot url you will onyl see the Onvif logo in certain places in Unifi Protect where it does not show the livestream.
-
-[^1]: [What is MacVLAN?](https://ipwithease.com/what-is-macvlan)
-[^2]: [Wikipedia: Locally Administered MAC Address](https://en.wikipedia.org/wiki/MAC_address#:~:text=Locally%20administered%20addresses%20are%20distinguished,how%20the%20address%20is%20administered.)
-[^3]: [UUIDv4 Generator](https://www.uuidgenerator.net/)
-[^4]: [Virtual Interfaces with different MAC addresses](https://serverfault.com/questions/682311/virtual-interfaces-with-different-mac-addresses)
-
+Daniela Hase wrote the original virtual ONVIF server. Piotr Kula (p10tyr) made it a docker appliance with auto MAC/IP registration and is upstream of this fork.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,6 +1,7 @@
 onvif:
   - name: BulletCam                               # A user define named that will show up in the consumer device. Use letters only, no spaces or special characters
     dev: enp2s0 #eth0                             # Network interface to add virtual IP's too. use ip addr to find your name
+    ptz: false                                    # Set true if this cam supports PTZ — proxy advertises the PTZ service and forwards ContinuousMove/Stop/etc.
     target:
       hostname: 192.168.1.187                      # Your cameras IPv4 address
       ports:

--- a/src/config-tools.js
+++ b/src/config-tools.js
@@ -13,7 +13,7 @@ function readConfig(logger, configFile) {
     } catch (error) {
         if (error.code === 'ENOENT') {
             logger.info(`File not found: ${configFile}`);
-            exit(-1);
+            process.exit(-1);
         }
         throw error;
     }
@@ -23,7 +23,7 @@ function readConfig(logger, configFile) {
         config = YAML.parse(configData);
     } catch (error) {
         logger.info('Failed to read config, invalid yaml syntax.')
-        exit(-1);
+        process.exit(-1);
     }
 
     return config;

--- a/src/events-proxy.js
+++ b/src/events-proxy.js
@@ -1,0 +1,111 @@
+const crypto = require('crypto');
+const { forwardSoap } = require('./soap-forwarder');
+
+const MAX_SUBSCRIPTIONS = 32;
+const SWEEP_INTERVAL_MS = 60_000;
+const DEFAULT_TTL_MS = 3600_000;
+const SWEEP_GRACE_MS = 300_000;
+
+const FAULT_REWRITE_FAILED = '<?xml version="1.0"?><s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Body><s:Fault><s:Code><s:Value>s:Receiver</s:Value></s:Code><s:Reason><s:Text>proxy address rewrite failed</s:Text></s:Reason></s:Fault></s:Body></s:Envelope>';
+const FAULT_SUBSCRIPTION_CAP = '<?xml version="1.0"?><s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Body><s:Fault><s:Code><s:Value>s:Sender</s:Value></s:Code><s:Reason><s:Text>subscription limit reached</s:Text></s:Reason></s:Fault></s:Body></s:Envelope>';
+
+module.exports = class EventsProxy {
+    constructor(logger, config) {
+        this.logger = logger;
+        this.config = config;
+        this.subscriptions = new Map();
+        this.cleanupTimer = setInterval(() => this.sweepExpired(), SWEEP_INTERVAL_MS);
+        if (this.cleanupTimer.unref) this.cleanupTimer.unref();
+    }
+
+    matches(pathname) {
+        return pathname === '/onvif/Events'
+            || pathname === '/onvif/events_service'
+            || pathname.startsWith('/onvif/subscription/');
+    }
+
+    upstreamEventsUrl() {
+        const port = (this.config.target.ports && this.config.target.ports.snapshot) || 80;
+        return `http://${this.config.target.hostname}:${port}/onvif/Events`;
+    }
+
+    async handle(request, response) {
+        const pathname = request.url.split('?')[0];
+        const isSubscriptionUrl = pathname.startsWith('/onvif/subscription/');
+
+        let upstreamUrl;
+        if (isSubscriptionUrl) {
+            const localId = pathname.slice('/onvif/subscription/'.length);
+            const sub = this.subscriptions.get(localId);
+            if (!sub) {
+                this.logger.info(`EVENTS: ${this.config.name} - unknown subscription ${localId}`);
+                response.writeHead(404, { 'content-type': 'text/plain' });
+                response.end('Subscription not found');
+                return;
+            }
+            upstreamUrl = sub.upstreamManagerUrl;
+        } else {
+            upstreamUrl = this.upstreamEventsUrl();
+        }
+
+        await forwardSoap({
+            logger: this.logger,
+            name: `${this.config.name}/events`,
+            request, response, upstreamUrl,
+            rewriteResponse: (respBody, reqBody) => {
+                if (!isSubscriptionUrl && /CreatePullPointSubscription/i.test(reqBody)) {
+                    return this.rewriteSubscriptionAddress(respBody);
+                }
+                if (isSubscriptionUrl) {
+                    const localId = pathname.slice('/onvif/subscription/'.length);
+                    if (/Unsubscribe/.test(reqBody) && /UnsubscribeResponse/.test(respBody)) {
+                        if (this.subscriptions.delete(localId)) {
+                            this.logger.info(`EVENTS: ${this.config.name} - unsubscribed ${localId}`);
+                        }
+                    } else if (/Renew/.test(reqBody) && /RenewResponse/.test(respBody)) {
+                        const sub = this.subscriptions.get(localId);
+                        if (sub) {
+                            const m = respBody.match(/<\s*(?:[\w-]+:)?TerminationTime\b[^>]*>([^<]+)/i);
+                            const parsed = m && Date.parse(m[1].trim());
+                            if (parsed && !Number.isNaN(parsed)) sub.terminationTime = parsed;
+                        }
+                    }
+                }
+                return null;
+            },
+        });
+    }
+
+    rewriteSubscriptionAddress(body) {
+        const re = /(<\s*(?:[\w-]+:)?SubscriptionReference\b[^>]*>[\s\S]*?<\s*(?:[\w-]+:)?Address\b[^>]*>)([\s\S]*?)(<\s*\/\s*(?:[\w-]+:)?Address\s*>)/i;
+        const m = body.match(re);
+        if (!m) {
+            this.logger.error(`EVENTS: ${this.config.name} - SubscriptionReference/Address not found in upstream response; refusing to leak upstream URL`);
+            return FAULT_REWRITE_FAILED;
+        }
+        if (this.subscriptions.size >= MAX_SUBSCRIPTIONS) {
+            this.logger.warn(`EVENTS: ${this.config.name} - subscription cap reached (${MAX_SUBSCRIPTIONS})`);
+            return FAULT_SUBSCRIPTION_CAP;
+        }
+        const upstreamUrl = m[2].trim();
+        const localId = crypto.randomUUID();
+        this.subscriptions.set(localId, {
+            upstreamManagerUrl: upstreamUrl,
+            createdAt: Date.now(),
+            terminationTime: Date.now() + DEFAULT_TTL_MS,
+        });
+        const ourUrl = `http://${this.config.hostname}:${this.config.ports.server}/onvif/subscription/${localId}`;
+        this.logger.info(`EVENTS: ${this.config.name} - subscription ${localId} -> ${upstreamUrl}`);
+        return body.replace(re, `$1${ourUrl}$3`);
+    }
+
+    sweepExpired() {
+        const now = Date.now();
+        for (const [id, sub] of this.subscriptions.entries()) {
+            if (sub.terminationTime < now - SWEEP_GRACE_MS) {
+                this.subscriptions.delete(id);
+                this.logger.info(`EVENTS: ${this.config.name} - sweeping expired subscription ${id}`);
+            }
+        }
+    }
+};

--- a/src/imaging-proxy.js
+++ b/src/imaging-proxy.js
@@ -1,0 +1,40 @@
+const { forwardSoap } = require('./soap-forwarder');
+
+const VIDEO_SOURCE_TOKEN_MAP = {
+    video_src_token: 'VideoSource_1',
+};
+
+function rewriteVideoSourceTokens(body) {
+    let out = body;
+    for (const [ours, theirs] of Object.entries(VIDEO_SOURCE_TOKEN_MAP)) {
+        out = out.replace(new RegExp(`>${ours}<`, 'g'), `>${theirs}<`);
+        out = out.replace(new RegExp(`="${ours}"`, 'g'), `="${theirs}"`);
+    }
+    return out === body ? null : out;
+}
+
+module.exports = class ImagingProxy {
+    constructor(logger, config) {
+        this.logger = logger;
+        this.config = config;
+    }
+
+    matches(pathname) {
+        return pathname === '/onvif/Imaging' || pathname === '/onvif/imaging_service';
+    }
+
+    upstreamImagingUrl() {
+        const port = (this.config.target.ports && this.config.target.ports.snapshot) || 80;
+        return `http://${this.config.target.hostname}:${port}/onvif/Imaging`;
+    }
+
+    async handle(request, response) {
+        await forwardSoap({
+            logger: this.logger,
+            name: `${this.config.name}/imaging`,
+            request, response,
+            upstreamUrl: this.upstreamImagingUrl(),
+            rewriteRequest: rewriteVideoSourceTokens,
+        });
+    }
+};

--- a/src/onvif-server.js
+++ b/src/onvif-server.js
@@ -8,6 +8,7 @@ const fs = require('fs');
 const logger = require('simple-node-logger');
 
 const { getIp4FromMac } = require('./net-tools')
+const EventsProxy = require('./events-proxy')
 
 Date.prototype.stdTimezoneOffset = function () {
     let jan = new Date(this.getFullYear(), 0, 1);
@@ -23,6 +24,7 @@ module.exports = class OnvifServer {
     constructor(logger, config) {
         this.config = config;
         this.logger = logger;
+        this.eventsProxy = new EventsProxy(logger, config);
 
         this.config.hostname = getIp4FromMac(logger, this.config.mac);
         if (!this.config.hostname)
@@ -235,6 +237,15 @@ module.exports = class OnvifServer {
                             }
                         }
 
+                        if (args.Category === undefined || args.Category == 'All' || args.Category == 'Events') {
+                            response.Capabilities['Events'] = {
+                                XAddr: `http://${this.config.hostname}:${this.config.ports.server}/onvif/Events`,
+                                WSSubscriptionPolicySupport: false,
+                                WSPullPointSupport: true,
+                                WSPausableSubscriptionManagerInterfaceSupport: false
+                            };
+                        }
+
                         return response;
                     },
 
@@ -244,18 +255,17 @@ module.exports = class OnvifServer {
                                 {
                                     Namespace: 'http://www.onvif.org/ver10/device/wsdl',
                                     XAddr: `http://${this.config.hostname}:${this.config.ports.server}/onvif/device_service`,
-                                    Version: {
-                                        Major: 2,
-                                        Minor: 5,
-                                    }
+                                    Version: { Major: 2, Minor: 5 }
                                 },
                                 {
                                     Namespace: 'http://www.onvif.org/ver10/media/wsdl',
                                     XAddr: `http://${this.config.hostname}:${this.config.ports.server}/onvif/media_service`,
-                                    Version: {
-                                        Major: 2,
-                                        Minor: 5,
-                                    }
+                                    Version: { Major: 2, Minor: 5 }
+                                },
+                                {
+                                    Namespace: 'http://www.onvif.org/ver10/events/wsdl',
+                                    XAddr: `http://${this.config.hostname}:${this.config.ports.server}/onvif/Events`,
+                                    Version: { Major: 2, Minor: 5 }
                                 }
                             ]
                         };
@@ -332,6 +342,8 @@ module.exports = class OnvifServer {
             let image = fs.readFileSync('./resources/snapshot.png');
             response.writeHead(200, { 'Content-Type': 'image/png' });
             response.end(image, 'binary');
+        } else if (this.eventsProxy.matches(action)) {
+            this.eventsProxy.handle(request, response);
         } else {
             response.writeHead(404, { 'Content-Type': 'text/plain' });
             response.write('404 Not Found\n');
@@ -342,7 +354,7 @@ module.exports = class OnvifServer {
     startHttpServer() {
         this.logger.info(`SERVER: ${this.config.name} - HTTP listening on ${this.config.hostname}:${this.config.ports.server}`);
 
-        this.server = http.createServer(this.listen);
+        this.server = http.createServer(this.listen.bind(this));
         this.server.listen(this.config.ports.server, this.config.hostname);
 
         this.deviceService = soap.listen(this.server, {

--- a/src/onvif-server.js
+++ b/src/onvif-server.js
@@ -426,6 +426,10 @@ module.exports = class OnvifServer {
         this.discoveryMessageNo = 0;
         this.discoverySocket = dgram.createSocket({ type: 'udp4', reuseAddr: true });
 
+        this.discoverySocket.on('error', (err) => {
+            this.logger.error(`DISCOVERY: ${this.config.name} - socket error: ${err.message}`);
+        });
+
         this.discoverySocket.on('message', (message, remote) => {
 
             this.logger.debug(`SERVER: ${this.config.name} - Discovery request from ${remote.address}:${remote.port}`);
@@ -476,7 +480,14 @@ module.exports = class OnvifServer {
 
                     this.discoveryMessageNo++;
                     let responseBuffer = Buffer.from(response);
-                    return dgram.createSocket('udp4').send(responseBuffer, 0, responseBuffer.length, remote.port, remote.address);
+                    const replySocket = dgram.createSocket('udp4');
+                    replySocket.on('error', (sendErr) => {
+                        this.logger.warn(`DISCOVERY: ${this.config.name} - reply send error: ${sendErr.message}`);
+                        replySocket.close();
+                    });
+                    replySocket.send(responseBuffer, 0, responseBuffer.length, remote.port, remote.address, () => {
+                        replySocket.close();
+                    });
                 }
             });
         });

--- a/src/onvif-server.js
+++ b/src/onvif-server.js
@@ -10,6 +10,7 @@ const logger = require('simple-node-logger');
 const { getIp4FromMac } = require('./net-tools')
 const EventsProxy = require('./events-proxy')
 const PtzProxy = require('./ptz-proxy')
+const ImagingProxy = require('./imaging-proxy')
 
 Date.prototype.stdTimezoneOffset = function () {
     let jan = new Date(this.getFullYear(), 0, 1);
@@ -27,6 +28,7 @@ module.exports = class OnvifServer {
         this.logger = logger;
         this.eventsProxy = new EventsProxy(logger, config);
         this.ptzProxy = config.ptz ? new PtzProxy(logger, config) : null;
+        this.imagingProxy = new ImagingProxy(logger, config);
 
         this.config.hostname = getIp4FromMac(logger, this.config.mac);
         if (!this.config.hostname)
@@ -254,6 +256,12 @@ module.exports = class OnvifServer {
                             };
                         }
 
+                        if (args.Category === undefined || args.Category == 'All' || args.Category == 'Imaging') {
+                            response.Capabilities['Imaging'] = {
+                                XAddr: `http://${this.config.hostname}:${this.config.ports.server}/onvif/Imaging`
+                            };
+                        }
+
                         return response;
                     },
 
@@ -279,7 +287,12 @@ module.exports = class OnvifServer {
                                     Namespace: 'http://www.onvif.org/ver20/ptz/wsdl',
                                     XAddr: `http://${this.config.hostname}:${this.config.ports.server}/onvif/PTZ`,
                                     Version: { Major: 2, Minor: 5 }
-                                }] : [])
+                                }] : []),
+                                {
+                                    Namespace: 'http://www.onvif.org/ver20/imaging/wsdl',
+                                    XAddr: `http://${this.config.hostname}:${this.config.ports.server}/onvif/Imaging`,
+                                    Version: { Major: 2, Minor: 5 }
+                                }
                             ]
                         };
                     },
@@ -359,6 +372,8 @@ module.exports = class OnvifServer {
             this.eventsProxy.handle(request, response);
         } else if (this.ptzProxy && this.ptzProxy.matches(action)) {
             this.ptzProxy.handle(request, response);
+        } else if (this.imagingProxy.matches(action)) {
+            this.imagingProxy.handle(request, response);
         } else {
             response.writeHead(404, { 'Content-Type': 'text/plain' });
             response.write('404 Not Found\n');

--- a/src/onvif-server.js
+++ b/src/onvif-server.js
@@ -9,6 +9,7 @@ const logger = require('simple-node-logger');
 
 const { getIp4FromMac } = require('./net-tools')
 const EventsProxy = require('./events-proxy')
+const PtzProxy = require('./ptz-proxy')
 
 Date.prototype.stdTimezoneOffset = function () {
     let jan = new Date(this.getFullYear(), 0, 1);
@@ -25,6 +26,7 @@ module.exports = class OnvifServer {
         this.config = config;
         this.logger = logger;
         this.eventsProxy = new EventsProxy(logger, config);
+        this.ptzProxy = config.ptz ? new PtzProxy(logger, config) : null;
 
         this.config.hostname = getIp4FromMac(logger, this.config.mac);
         if (!this.config.hostname)
@@ -246,6 +248,12 @@ module.exports = class OnvifServer {
                             };
                         }
 
+                        if (this.ptzProxy && (args.Category === undefined || args.Category == 'All' || args.Category == 'PTZ')) {
+                            response.Capabilities['PTZ'] = {
+                                XAddr: `http://${this.config.hostname}:${this.config.ports.server}/onvif/PTZ`
+                            };
+                        }
+
                         return response;
                     },
 
@@ -266,7 +274,12 @@ module.exports = class OnvifServer {
                                     Namespace: 'http://www.onvif.org/ver10/events/wsdl',
                                     XAddr: `http://${this.config.hostname}:${this.config.ports.server}/onvif/Events`,
                                     Version: { Major: 2, Minor: 5 }
-                                }
+                                },
+                                ...(this.ptzProxy ? [{
+                                    Namespace: 'http://www.onvif.org/ver20/ptz/wsdl',
+                                    XAddr: `http://${this.config.hostname}:${this.config.ports.server}/onvif/PTZ`,
+                                    Version: { Major: 2, Minor: 5 }
+                                }] : [])
                             ]
                         };
                     },
@@ -344,6 +357,8 @@ module.exports = class OnvifServer {
             response.end(image, 'binary');
         } else if (this.eventsProxy.matches(action)) {
             this.eventsProxy.handle(request, response);
+        } else if (this.ptzProxy && this.ptzProxy.matches(action)) {
+            this.ptzProxy.handle(request, response);
         } else {
             response.writeHead(404, { 'Content-Type': 'text/plain' });
             response.write('404 Not Found\n');
@@ -432,7 +447,7 @@ module.exports = class OnvifServer {
                                         <d:Types>dn:NetworkVideoTransmitter</d:Types>
                                         <d:Scopes>
                                             onvif://www.onvif.org/type/video_encoder
-                                            onvif://www.onvif.org/type/ptz
+                                            ${this.ptzProxy ? 'onvif://www.onvif.org/type/ptz' : ''}
                                             onvif://www.onvif.org/hardware/onvif
                                             onvif://www.onvif.org/name/${this.config.name}
                                             onvif://www.onvif.org/location/

--- a/src/ptz-proxy.js
+++ b/src/ptz-proxy.js
@@ -1,0 +1,41 @@
+const { forwardSoap } = require('./soap-forwarder');
+
+const PROFILE_TOKEN_MAP = {
+    main_stream: 'Profile_1',
+    sub_stream: 'Profile_2',
+};
+
+function rewriteProfileTokens(body) {
+    let out = body;
+    for (const [ours, theirs] of Object.entries(PROFILE_TOKEN_MAP)) {
+        out = out.replace(new RegExp(`>${ours}<`, 'g'), `>${theirs}<`);
+        out = out.replace(new RegExp(`="${ours}"`, 'g'), `="${theirs}"`);
+    }
+    return out === body ? null : out;
+}
+
+module.exports = class PtzProxy {
+    constructor(logger, config) {
+        this.logger = logger;
+        this.config = config;
+    }
+
+    matches(pathname) {
+        return pathname === '/onvif/PTZ' || pathname === '/onvif/ptz_service';
+    }
+
+    upstreamPtzUrl() {
+        const port = (this.config.target.ports && this.config.target.ports.snapshot) || 80;
+        return `http://${this.config.target.hostname}:${port}/onvif/PTZ`;
+    }
+
+    async handle(request, response) {
+        await forwardSoap({
+            logger: this.logger,
+            name: `${this.config.name}/ptz`,
+            request, response,
+            upstreamUrl: this.upstreamPtzUrl(),
+            rewriteRequest: rewriteProfileTokens,
+        });
+    }
+};

--- a/src/soap-forwarder.js
+++ b/src/soap-forwarder.js
@@ -1,0 +1,113 @@
+const http = require('http');
+
+const MAX_BODY_BYTES = 256 * 1024;
+
+const STRIP_REQ = new Set(['host', 'connection', 'content-length', 'transfer-encoding', 'expect']);
+const STRIP_RES = new Set(['connection', 'content-length', 'transfer-encoding', 'set-cookie', 'www-authenticate', 'proxy-authenticate', 'server']);
+
+function readBody(request) {
+    return new Promise((resolve, reject) => {
+        const chunks = [];
+        let size = 0;
+        request.on('data', (c) => {
+            size += c.length;
+            if (size > MAX_BODY_BYTES) {
+                request.destroy();
+                reject(new Error(`request body exceeds ${MAX_BODY_BYTES} bytes`));
+                return;
+            }
+            chunks.push(c);
+        });
+        request.on('end', () => resolve(Buffer.concat(chunks)));
+        request.on('error', reject);
+    });
+}
+
+function forward(targetUrl, headers, body) {
+    return new Promise((resolve, reject) => {
+        const u = new URL(targetUrl);
+        const req = http.request({
+            method: 'POST',
+            hostname: u.hostname,
+            port: u.port || 80,
+            path: u.pathname + u.search,
+            headers: {
+                ...headers,
+                host: u.host,
+                'content-length': Buffer.byteLength(body),
+            },
+            timeout: 15000,
+        }, (res) => {
+            res.on('error', reject);
+            const chunks = [];
+            res.on('data', (c) => chunks.push(c));
+            res.on('end', () => resolve({
+                statusCode: res.statusCode,
+                headers: res.headers,
+                body: Buffer.concat(chunks),
+            }));
+        });
+        req.on('error', reject);
+        req.on('timeout', () => req.destroy(new Error('upstream timeout')));
+        req.end(body);
+    });
+}
+
+function sanitizeRequestHeaders(headers) {
+    const out = {};
+    for (const [k, v] of Object.entries(headers)) {
+        if (!STRIP_REQ.has(k.toLowerCase())) out[k] = v;
+    }
+    return out;
+}
+
+function sanitizeResponseHeaders(headers) {
+    const out = {};
+    for (const [k, v] of Object.entries(headers)) {
+        if (!STRIP_RES.has(k.toLowerCase())) out[k] = v;
+    }
+    return out;
+}
+
+async function forwardSoap({ logger, name, request, response, upstreamUrl, rewriteRequest, rewriteResponse }) {
+    try {
+        const reqBody = await readBody(request);
+        let body = reqBody.toString('utf8');
+        if (typeof rewriteRequest === 'function') {
+            const r = rewriteRequest(body);
+            if (r != null) body = r;
+        }
+
+        const upstreamResp = await forward(upstreamUrl, sanitizeRequestHeaders(request.headers), Buffer.from(body, 'utf8'));
+
+        if (upstreamResp.statusCode >= 400) {
+            const snippet = upstreamResp.body.toString('utf8').slice(0, 200).replace(/\s+/g, ' ');
+            logger.warn(`PROXY: ${name} - upstream ${upstreamResp.statusCode}: ${snippet}`);
+        }
+
+        let outBody = upstreamResp.body;
+        if (typeof rewriteResponse === 'function') {
+            const r = rewriteResponse(outBody.toString('utf8'), body);
+            if (r != null) outBody = Buffer.from(r, 'utf8');
+        }
+
+        const respHeaders = sanitizeResponseHeaders(upstreamResp.headers);
+        respHeaders['content-length'] = Buffer.byteLength(outBody);
+        response.writeHead(upstreamResp.statusCode, respHeaders);
+        response.end(outBody);
+    } catch (err) {
+        logger.error(`PROXY: ${name} - ${err.message}`);
+        if (!response.headersSent) {
+            response.writeHead(502, { 'content-type': 'text/plain' });
+            response.end(`Upstream proxy failure: ${err.message}`);
+        }
+    }
+}
+
+module.exports = {
+    readBody,
+    forward,
+    sanitizeRequestHeaders,
+    sanitizeResponseHeaders,
+    forwardSoap,
+};


### PR DESCRIPTION
# Proxy ONVIF Events and PTZ to upstream camera

Adds two raw SOAP forwarders so motion events and PTZ controls work through the proxy instead of dead-ending at the fabricated facade. Required for Protect 7.1.55 (third-party motion alerts) and AI Port (PTZ).

## Events service

`/onvif/Events` forwards to upstream. `CreatePullPointSubscription` responses contain a `SubscriptionReference.Address` pointing directly at the upstream cam, which would let clients bypass the proxy. Rewritten to point at `/onvif/subscription/{uuid}` on this proxy, with `{uuid -> upstream sub URL}` kept in memory.

`PullMessages`, `Renew`, `Unsubscribe` against `/onvif/subscription/{uuid}` look up the upstream URL and forward. `Unsubscribe` removes the local entry, `Renew` updates the cached `TerminationTime`. A 60s sweep clears anything past its TTL plus a 5min grace. Hard cap of 32 active subs per cam.

If the upstream response shape doesn't have a recognizable `<SubscriptionReference><Address>` to rewrite, returns a SOAP fault rather than leaking the upstream URL through.

## PTZ service

`/onvif/PTZ` forwards to upstream. Gated on `ptz: true` per cam in config (same pattern as the existing `lowQuality:` capability flag).

The fork's `GetProfiles` returns hardcoded tokens `main_stream` / `sub_stream`. Real Hikvision-family cams use `Profile_1` / `Profile_2`. Without translation, UniFi reads our profiles, sends `ContinuousMove ProfileToken=main_stream`, cam returns `ter:NoProfile`. The PTZ forwarder rewrites `main_stream -> Profile_1` and `sub_stream -> Profile_2` in the request body before forwarding. Hardcoded; could be config-driven if other cam families need different mappings.

## Auth

No credentials in config. Clients send a `wsse:Security` UsernameToken at every request based on the password entered at adoption, and the proxy forwards that header unchanged. Verified by computing the captured Protect PasswordDigest against the known cam password and matching.

## Other

`exit(-1)` -> `process.exit(-1)` in `src/config-tools.js`. The undefined `exit` never fired on the happy path but would crash on missing config file or YAML parse error.

## Tested on

- Six Luma Surveillance cameras (Hikvision OEM rebrand) on an isolated `192.168.254.0/24` VLAN
- 4x LUM-310-DOM-IP-BL fixed dome, firmware V5.5.52 build 210429
- 1x LUM-310-PTZ-IP-WH, firmware V5.5.6 build 201111
- 1x LUM-510-PTZ-IP-WH, firmware V5.5.6 build 201111
- Running on a Raspberry Pi as a systemd service (not Docker), existing macvlan bridges
- UDM with Protect 7.1.55 beta

What was checked:

- `GetEventProperties` topic dump per cam to confirm what motion topics they actually expose
- `tcpdump` on the proxy ports during normal Protect operation, confirmed Protect does `CreatePullPointSubscription` -> `PullMessages` cycles against `/onvif/subscription/{uuid}` and gets real notifications back
- Walked in front of cams; `MotionAlarm Value=true` and `CellMotionDetector/Motion IsMotion=true` flow through verbatim
- PTZ joystick in Protect physically moved Pool and BackView, `ContinuousMoveResponse` / `StopResponse` returned cleanly
- Cut over from previous deployment without re-adopting any cams. WS-Security passthrough worked because Protect already had the real cam password from original adoption
- Subscription map stayed bounded under sustained polling, sweep cleaned up correctly

## Not implemented

- **PTZ auto-detection**: forwarding `GetCapabilities` upstream and observing the PTZ XAddr would do it, but cleanly requires either creds in config or pulling `device_service` out of the soap library binding to handle as raw HTTP. Used a per-cam `ptz: true` flag instead.
- **Subscription fan-out**: each downstream client gets its own upstream subscription. Cams advertise `MaxPullPoints=10`, our cap is 32, so a misbehaving client is the only realistic way to hit a limit.
- **Smart event topics** (`RuleEngine/ObjectDetector` etc.): the cams I tested are too old to emit them. The proxy passes through whatever the cam advertises, so should work if the cam emits them, but unverified.